### PR TITLE
Update digiid.php

### DIFF
--- a/core/digiid.php
+++ b/core/digiid.php
@@ -36,6 +36,7 @@ require_once("Signature.php");
 require_once("NumberTheory.php");
 require_once("PublicKeyInterface.php");
 require_once("PublicKey.php");
+require_once("digiidcallback.php");
 
 
 /**


### PR DESCRIPTION
Added require_once("digiidcallback.php"); to avoid following error on UCP

Fatal error: Class 'DigiByte\digiid\core\DigiIDCallback' not found in /home/public_html/ext/DigiByte/digiid/ucp/main_module.php on line 39